### PR TITLE
Bugfixes and Support for T48G

### DIFF
--- a/sipXyealink/etc/yealinkPhone/line-7X.properties
+++ b/sipXyealink/etc/yealinkPhone/line-7X.properties
@@ -1,7 +1,7 @@
 type.codecs_type.9\:G722=G.722 (HD Audio)
-type.codecs_type.8\:PCMA=G.711
+type.codecs_type.8\:PCMA=G.711a
 type.codecs_type.18\:G729=G.729
-type.codecs_type.0\:PCMU=G.711
+type.codecs_type.0\:PCMU=G.711µ
 type.codecs_type.4\:G723_53=G.723 5.3 KBit
 type.codecs_type.4\:G723_63=G.723 6.3 KBit
 type.codecs_type.112\:G726-16=G.726 16 KBit

--- a/sipXyealink/etc/yealinkPhone/phone-7X.xml
+++ b/sipXyealink/etc/yealinkPhone/phone-7X.xml
@@ -700,7 +700,8 @@
 	</group>
 	<group name="ADVANCED" advanced="yes">
 	    <!--// Configure the volume of the side tone. It ranges from -48 to 0, the default value is -3. //-->
-	    <setting name="voice.side_tone"><type><integer min="-48" max="0"/></type><value>-3</value></setting>
+	    <!--// Value of -32768 disables this annoying side tone //-->
+	    <setting name="voice.side_tone"><type><integer min="-32768" max="0"/></type><value>-32768</value></setting>
 	</group>
     </group>
     <group name="distinctive-ringer">

--- a/sipXyealink/etc/yealinkPhone/upload.xml
+++ b/sipXyealink/etc/yealinkPhone/upload.xml
@@ -149,6 +149,17 @@
     		</type>
 		<description>Firmware binary in 28.x.x.x.rom</description>
         </setting>
+	<setting name="yealink_SIP-T48.rom">
+    		<label>SIP-T48G</label>
+    		<type>
+    			<file>
+    				<contentType>application/binary</contentType>
+    				<rename>T48.rom</rename>
+    				<moveTo>../</moveTo>
+    			</file>
+    		</type>
+		<description>Firmware binary in 35.x.x.x.rom</description>
+        </setting>
         <setting name="Logo132x64.dob">
             <label>SIP-T2X LCD Logo (screensaver)</label>
             <type>

--- a/sipXyealink/src/org/sipfoundry/sipxconfig/phone/yealink/YealinkConstants.java
+++ b/sipXyealink/src/org/sipfoundry/sipxconfig/phone/yealink/YealinkConstants.java
@@ -31,7 +31,7 @@ public abstract class YealinkConstants {
     public static final String PKTYPES_V6X = "0,2,5,6,7,8,13,22,28,29,30,31,32,33,39,43,44,45,46,47";
     public static final String PKTYPES_V70 = "0,2,5,6,7,8,9,13,14,22,23,27,28,29,30,32,33,43,44,45,46,47,48,49,50";
     public static final String DKTYPES_V70 = "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,"
-            + "27,34,35,38,39,40,41,42,45,46";
+            + "27,34,35,38,39,40,41,42,45,46,47";
     public static final String DKTYPES_V71 = "0,11,12,13,14,15,16,17,18,22,23,24,25,27,34,35,38,40";
 
     // Line specific settings used in /etc/yealinkPhone/line_XX.xml
@@ -114,6 +114,7 @@ public abstract class YealinkConstants {
     public static final String AUTOPROVISIONING_SERVER_ADDRESS_V6X_SETTING = "upgrade/autoprovision/server_address";
     public static final String ADVANCED_MUSIC_SERVER_URI_V6X_SETTING = "account/MusicServerUri";
     public static final String ADVANCED_MUSIC_SERVER_URI_V7X_SETTING = "advanced/music_server_uri";
+	public static final String ADVANCED_BLF_SERVER_URI_V7X_SETTING = "advanced/blf.blf_list_uri";
     // T2X except T20
     public static final String LOGO_FILE_NAME_V6X_SETTING = "upgrade/Logo/server_address";
     public static final String LOGO_FILE_NAME_V7X_SETTING = "features/GENERAL/lcd_logo.url";

--- a/sipXyealink/src/org/sipfoundry/sipxconfig/phone/yealink/YealinkLineDefaults.java
+++ b/sipXyealink/src/org/sipfoundry/sipxconfig/phone/yealink/YealinkLineDefaults.java
@@ -19,6 +19,7 @@ package org.sipfoundry.sipxconfig.phone.yealink;
 
 import org.sipfoundry.sipxconfig.address.Address;
 import org.sipfoundry.sipxconfig.common.User;
+import org.sipfoundry.sipxconfig.common.SipUri;
 import org.sipfoundry.sipxconfig.device.DeviceDefaults;
 import org.sipfoundry.sipxconfig.phone.Line;
 import org.sipfoundry.sipxconfig.setting.SettingEntry;
@@ -145,6 +146,19 @@ public class YealinkLineDefaults {
             mohUri = m_defaults.getMusicOnHoldUri();
         }
         return mohUri;
+    }
+
+	@SettingEntry(paths = {
+            YealinkConstants.ADVANCED_BLF_SERVER_URI_V7X_SETTING })
+    public String getRlsServerUri() {
+        String rlsUri;
+        User u = m_line.getUser();
+        if (u != null) {
+            rlsUri = SipUri.format("~~rl~C~"+u.getUserName(), m_defaults.getDomainName(), false);
+        } else {
+            rlsUri = "";
+        }
+        return rlsUri;
     }
 
 }

--- a/sipXyealink/src/org/sipfoundry/sipxconfig/phone/yealink/YealinkPhone.java
+++ b/sipXyealink/src/org/sipfoundry/sipxconfig/phone/yealink/YealinkPhone.java
@@ -74,7 +74,7 @@ import org.sipfoundry.sipxconfig.upload.yealink.YealinkUpload;
 public class YealinkPhone extends Phone {
     public static final String BEAN_ID = "yealink";
     private static final Log LOG = LogFactory.getLog(YealinkPhone.class);
-    private static final String SIPT46_PATTERN = "yealinkPhoneSIPT46.*";
+    private static final String SIPT46_PATTERN = "yealinkPhoneSIPT4[6-8].*";
     private static final String SIPT412_PATTERN = "yealinkPhoneSIPT4[12].*";
     private static final String SIPT4_PATTERN = "yealinkPhoneSIPT4.*";
     private static final String SIPT13_PATTERN = "yealinkPhoneSIPT[1-3].*";

--- a/sipXyealink/src/sipxplugin.beans.xml
+++ b/sipXyealink/src/sipxplugin.beans.xml
@@ -7,7 +7,6 @@
     <property name="registrarSettings" ref="registrarSettings"/>
     <property name="uploadManager" ref="uploadManager"/>
     <property name="ldapManager" ref="ldapManager"/>
-    <property name="addressManager" ref="addressManager"/>
 </bean>
 
 <bean id="org.sipfoundry.sipxconfig.phone.yealink.YealinkModel.VER_6X"
@@ -199,6 +198,24 @@
 <bean id="yealinkPhoneSIPT46G" parent="yealinkModel">
 	<property name="label" value="Yealink SIP-T46G" />
 	<property name="name" value="T46" />
+	<property name="maxLineCount" value="6" />
+	<property name="maxDSSKeyCount" value="21" />
+	<property name="supportedFeatures">
+	    <set>
+		<value>hasHDSound</value>
+		<value>hasPhoneBook</value>
+		<value>hasRingTones</value>
+		<value>hasWallPapers</value>
+		<value>hasScreenSavers</value>
+		<value>hasExpansionPanels</value>
+		<value>hasLanguages</value>
+	    </set>
+	</property>
+</bean>
+
+<bean id="yealinkPhoneSIPT48G" parent="yealinkModel">
+	<property name="label" value="Yealink SIP-T48G" />
+	<property name="name" value="T48" />
 	<property name="maxLineCount" value="6" />
 	<property name="maxDSSKeyCount" value="21" />
 	<property name="supportedFeatures">


### PR DESCRIPTION
Done some work to yealink plugin. Please check and feel free to use.
- FIX:
- annoying sidetone is now disabled by default. Can be reenabled by GUI
- Audio-Codecs G711a and G711u can now be identified correctly inside GUI
- RLS-Server list will now be set correct by default
- ADD:
- Basic support for Yealink T48G added

We've tested this for last 2 weeks without problems.

Regards
Claas
