### PR TITLE
[SIPX-275] Polycom Configuration improvements

### DIFF
--- a/sipXpolycom/etc/polycom/line-40.properties
+++ b/sipXpolycom/etc/polycom/line-40.properties
@@ -160,6 +160,12 @@ reg.serverFeatureControl.callRecording.description=Enable/disable server-based c
 voIpProt.SIP.serverFeatureControl.securityClassification.label=Security Classification
 voIpProt.SIP.serverFeatureControl.securityClassification.description=Use to configure Security Classification levels.
 
+reg.acd-login-logout.label=ACD Login Logout
+reg.acd-login-logout.description=Enable/disable ACD Login Logout on this line
+
+reg.acd-agent-available.label=ACD Agent available
+reg.acd-agent-available.description=Enable/disable ACD Agent available on this line
+
 call.label=Call Handling
 call.description=
 

--- a/sipXpolycom/etc/polycom/line-4_5.xml
+++ b/sipXpolycom/etc/polycom/line-4_5.xml
@@ -133,13 +133,13 @@
       </type>
       <value>0</value>
     </setting>
-    <setting name="serverFeatureControl.callRecording" if="5.1.1||5.1.2||5.1.3||5.2.0">
+    <setting name="serverFeatureControl.callRecording" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <boolean />
       </type>
       <value>0</value>
     </setting>
-      <setting name="securityClassification" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="securityClassification" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
         <type>
           <boolean />
         </type>
@@ -150,6 +150,18 @@
         <string />
       </type>
       <value />
+    </setting>
+    <setting name="acd-login-logout">
+      <type>
+        <boolean />
+      </type>
+      <value>0</value>
+    </setting>
+	<setting name="acd-agent-available">
+      <type>
+        <boolean />
+      </type>
+      <value>0</value>
     </setting>
     <group name="server">
       <group name="1">

--- a/sipXpolycom/etc/polycom/mac-address.d.40/features.cfg.vm
+++ b/sipXpolycom/etc/polycom/mac-address.d.40/features.cfg.vm
@@ -95,22 +95,36 @@
     roaming_privacy.${setting.ProfileName}="$!{setting.Value}"
 #end
   />
-#if ($phone.Model.ModelId == "polycomVVX500" || $phone.Model.ModelId == "polycomVVX410")
-#set ($group = $cfg.EndpointSettings.getSetting('polycomVVX500bg'))
+#if ($phone.Model.ModelId == "polycomVVX500" || $phone.Model.ModelId == "polycomVVX410" || $phone.Model.ModelId == "polycomVVX400")
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycomVVX500bg'))
+#if($group.getSetting('enabled').Value == 1)
   <bg>
     <bg.color bg.color.selection="$group.getSetting('selection').Value">
       <bg.color.bm bg.color.bm.1.em.name="$group.getSetting('bm.1.em.name').Value" bg.color.bm.1.name="$group.getSetting('bm.1.name').Value" />
     </bg.color>
   </bg>
+#end
+#elseif($phone.Model.ModelId == "polycomVVX300" || $phone.Model.ModelId == "polycomVVX310")
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycomVVX300bg'))
+#if($group.getSetting('enabled').Value == 1)
+  <bg>
+    <bg.color bg.color.selection="$group.getSetting('selection').Value">
+      <bg.color.bm bg.color.bm.1.em.name="$group.getSetting('bm.1.em.name').Value" bg.color.bm.1.name="$group.getSetting('bm.1.name').Value" />
+    </bg.color>
+  </bg>
+#end
 #elseif($phone.Model.ModelId == "polycomVVX600")
-#set ($group = $cfg.EndpointSettings.getSetting('polycomVVX600bg'))
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycomVVX600bg'))
+#if($group.getSetting('enabled').Value == 1)
   <bg>
     <bg.color bg.color.selection="$group.getSetting('selection').Value">
       <bg.color.bm bg.color.bm.1.em.name="$group.getSetting('bm.1.em.name').Value" bg.color.bm.1.name="$group.getSetting('bm.1.name').Value" />
     </bg.color>
   </bg>
+#end
 #elseif($phone.Model.ModelId == "polycomVVX1500")
-#set ($group = $cfg.EndpointSettings.getSetting('polycomVVX1500bg'))
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycomVVX1500bg'))
+#if($group.getSetting('enabled').Value == 1)
   <bg>
     <bg.VVX_1500>
       <bg.VVX_1500.color bg.VVX_1500.color.selection="$group.getSetting('selection').Value">
@@ -118,8 +132,10 @@
       </bg.VVX_1500.color>
     </bg.VVX_1500>
   </bg>
+#end
 #elseif($phone.Model.ModelId == "polycom670")
-#set ($group = $cfg.EndpointSettings.getSetting('polycom670bg'))
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycom670bg'))
+#if($group.getSetting('enabled').Value == 1)
   <bg>
     <bg.hiRes>
       <bg.hiRes.color bg.hiRes.color.selection="$group.getSetting('selection').Value">
@@ -127,8 +143,10 @@
       </bg.hiRes.color>
     </bg.hiRes>
   </bg>
+#end
 #elseif($phone.Model.ModelId == "polycom450")
-#set ($group = $cfg.EndpointSettings.getSetting('polycom450bg'))
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycom450bg'))
+#if($group.getSetting('enabled').Value == 1)
   <bg>
     <bg.medRes>
       <bg.medRes.gray bg.medRes.gray.selection="$group.getSetting('selection').Value">
@@ -136,8 +154,10 @@
       </bg.medRes.gray>
     </bg.medRes>
   </bg>
+#end
 #elseif($phone.Model.ModelId == "polycom550" || $phone.Model.ModelId == "polycom560" || $phone.Model.ModelId == "polycom650")
-#set ($group = $cfg.EndpointSettings.getSetting('polycom550bg'))
+#set ($group = $cfg.EndpointSettings.getSetting('background').getSetting('polycom550bg'))
+#if($group.getSetting('enabled').Value == 1)
   <bg>
     <bg.hiRes>
       <bg.hiRes.gray bg.hiRes.gray.selection="$group.getSetting('selection').Value">
@@ -145,5 +165,6 @@
       </bg.hiRes.gray>
     </bg.hiRes>
   </bg>
+#end
 #end
 </polycomConfig>

--- a/sipXpolycom/etc/polycom/mac-address.d.40/reg-advanced.cfg.vm
+++ b/sipXpolycom/etc/polycom/mac-address.d.40/reg-advanced.cfg.vm
@@ -17,8 +17,6 @@
 #foreach ($setting in $cfg.getRecursiveSettings($reg))
     reg.${i}.${setting.ProfileName}="$!{setting.Value}"
 #end
-    reg.${i}.acd-login-logout="0"
-    reg.${i}.acd-agent-available="0"
     reg.${i}.proxyRequire=""
 #end
   />

--- a/sipXpolycom/etc/polycom/mac-address.d.40/site.cfg.vm
+++ b/sipXpolycom/etc/polycom/mac-address.d.40/site.cfg.vm
@@ -437,11 +437,20 @@ sec.TLS.profile.1.caCert.platform2="0"
 />
 #end
 
-#set ($softKey = $cfg.EndpointSettings.getSetting('softKey'))
-#if($softKey)
+#set ($softKeyFeature = $cfg.EndpointSettings.getSetting('softKey').getSetting('feature'))
+#if($softKeyFeature)
 <softKey
-#foreach ($setting in $cfg.getRecursiveSettings($softKey))
-          softKey.${setting.ProfileName}="$!{setting.Value}"
+#foreach ($setting in $cfg.getRecursiveSettings($softKeyFeature))
+          softKey.feature.${setting.ProfileName}="$!{setting.Value}"
+#end
+/>
+#end
+
+#set ($softKeyEfk = $cfg.EndpointSettings.getSetting('softKey').getSetting('efk'))
+#if($softKeyEfk)
+<change
+#foreach ($setting in $cfg.getRecursiveSettings($softKeyEfk))
+          efk.${setting.ProfileName}="$!{setting.Value}"
 #end
 />
 #end

--- a/sipXpolycom/etc/polycom/mac-address.d.40/site.cfg.vm
+++ b/sipXpolycom/etc/polycom/mac-address.d.40/site.cfg.vm
@@ -334,6 +334,11 @@
     device.syslog.${setting.ProfileName}="$!{setting.Value}"
 #end
 
+#set ($group = $cfg.EndpointSettings.getSetting('auth'))
+#foreach ($setting in $cfg.getSettings($group))
+    device.auth.${setting.ProfileName}="$!{setting.Value}"
+#end
+
 #set ($group = $cfg.EndpointSettings.getSetting('network').getSetting('device.net'))
 #if ($cfg.EndpointSettings.getSetting('network').getSetting('device.net').getSetting('overwrite').Value != 0)
 #foreach ($setting in $cfg.getSettings($group))

--- a/sipXpolycom/etc/polycom/phone-40.properties
+++ b/sipXpolycom/etc/polycom/phone-40.properties
@@ -1106,6 +1106,18 @@ key.scrolling.timeout.description=The time-out after which a key that is enabled
  navigation keys (left, right, up, down arrows), volume keys, and some context-specific  \
  soft keys. The value is an integer multiple of 500 milliseconds (1=500ms).
 
+
+auth.label=Authentication
+auth.description=
+auth.localAdminPassword.set.label=Set Admin Password
+auth.localAdminPassword.set.description=Enable/Disable Admin Password overwrite
+auth.localAdminPassword.label=Admin Password
+auth.localAdminPassword.description=Polycom default is 456
+auth.localUserPassword.set.label=Set User Password
+auth.localUserPassword.set.description=Enable/Disable User Password overwrite
+auth.localUserPassword.label=User Password
+auth.localUserPassword.description=Polycom default is 456
+
 # common for log levels
 log_level.label.0=Debug only
 log_level.label.1=High detail
@@ -1493,10 +1505,16 @@ voIpProt.SIP.serverFeatureControl.label=Server Feature Control
 voIpProt.SIP.serverFeatureControl.description=
 
 voIpProt.SIP.serverFeatureControl.cf.label=Server Based Call Forwarding
-voIpProt.SIP.serverFeatureControl.cf.description=
+voIpProt.SIP.serverFeatureControl.cf.description= Enable or disable server-based call forwarding.
+
+voIpProt.SIP.serverFeatureControl.localProcessing.cf.label=Server Based Call Forwarding Local Processing
+voIpProt.SIP.serverFeatureControl.localProcessing.cf.description= Enable or disable local call forwarding behavior when server-based call forwarding is enabled.
 
 voIpProt.SIP.serverFeatureControl.dnd.label=Server Based Do Not Disturb
-voIpProt.SIP.serverFeatureControl.dnd.description=
+voIpProt.SIP.serverFeatureControl.dnd.description= Enable or disable server-based DND.
+
+voIpProt.SIP.serverFeatureControl.localProcessing.dnd.label=Server Based DNo Not Disturb Local Processing
+voIpProt.SIP.serverFeatureControl.localProcessing.dnd.description= Enable or disable local DND behavior when server-based enabled.
 
 voIpProt.SIP.serverFeatureControl.callRecording.label=Server Based Call Recording
 voIpProt.SIP.serverFeatureControl.callRecording.description=Check to enable this feature for all registration lines on the phone.
@@ -2026,6 +2044,86 @@ group.version.label=Group Firmware
 group.version.description=Change firmware version on a group of phones.
 group.version.firmware.version.label=Apply firmware version
 group.version.firmware.version.description=Use this in order to change the firmware version for all the phones in the group. Leave blank if you do not want to update phones firmware (for instance if you have phones with different versions in the group.)
+
+background.label=Device Background
+background.description=
+
+background.polycomVVX300bg.label=Background Polycom VVX 310/300
+background.polycomVVX300bg.description=
+background.polycomVVX300bg.enabled.label=Enable/Disable background configuration
+background.polycomVVX300bg.enabled.description=This affects only the provisioning
+background.polycomVVX300bg.selection.label=Selection
+background.polycomVVX300bg.selection.description=
+background.polycomVVX300bg.bm.1.name.label=Background Phone
+background.polycomVVX300bg.bm.1.name.description=For Main Screen
+background.polycomVVX300bg.bm.1.em.name.label=Background Expansion Module
+background.polycomVVX300bg.bm.1.em.name.description=For first Expansion Module
+
+background.polycomVVX500bg.label=Background Polycom VVX 500/410/400
+background.polycomVVX500bg.description=
+background.polycomVVX500bg.enabled.label=Enable/Disable background configuration
+background.polycomVVX500bg.enabled.description=This affects only the provisioning
+background.polycomVVX500bg.selection.label=Selection
+background.polycomVVX500bg.selection.description=
+background.polycomVVX500bg.bm.1.name.label=Background Phone
+background.polycomVVX500bg.bm.1.name.description=For Main Screen
+background.polycomVVX500bg.bm.1.em.name.label=Background Expansion Module
+background.polycomVVX500bg.bm.1.em.name.description=For first Expansion Module
+
+background.polycomVVX600bg.label=Background Polycom VVX 600
+background.polycomVVX600bg.description=
+background.polycomVVX600bg.enabled.label=Enable/Disable background configuration
+background.polycomVVX600bg.enabled.description=This affects only the provisioning
+background.polycomVVX600bg.selection.label=Selection
+background.polycomVVX600bg.selection.description=
+background.polycomVVX600bg.bm.1.name.label=Background Phone
+background.polycomVVX600bg.bm.1.name.description=For Main Screen
+background.polycomVVX600bg.bm.1.em.name.label=Background Expansion Module
+background.polycomVVX600bg.bm.1.em.name.description=For first Expansion Module
+
+background.polycomVVX1500bg.label=Background Polycom VVX 1500
+background.polycomVVX1500bg.description=
+background.polycomVVX1500bg.enabled.label=Enable/Disable background configuration
+background.polycomVVX1500bg.enabled.description=This affects only the provisioning
+background.polycomVVX1500bg.selection.label=Selection
+background.polycomVVX1500bg.selection.description=
+background.polycomVVX1500bg.bm.1.em.name.label=Background Expansion Module
+background.polycomVVX1500bg.bm.1.em.name.description=For first Expansion Module
+
+background.polycom550bg.label=Background Polycom SoundPoint IP 550
+background.polycom550bg.description=
+background.polycom550bg.enabled.label=Enable/Disable background configuration
+background.polycom550bg.enabled.description=This affects only the provisioning
+background.polycom550bg.selection.label=Selection
+background.polycom550bg.selection.description=
+background.polycom550bg.bm.1.name.label=Background Phone
+background.polycom550bg.bm.1.name.description=For Main Screen
+background.polycom550bg.bm.1.em.name.label=Background Expansion Module
+background.polycom550bg.bm.1.em.name.description=For first Expansion Module
+background.polycom550bg.bm.1.adj.label=Adjust
+background.polycom550bg.bm.1.adj.description=
+
+background.polycom670bg.label=Background Polycom SoundPoint IP 670
+background.polycom670bg.description=
+background.polycom670bg.enabled.label=Enable/Disable background configuration
+background.polycom670bg.enabled.description=This affects only the provisioning
+background.polycom670bg.selection.label=Selection
+background.polycom670bg.selection.description=
+background.polycom670bg.bm.1.name.label=Background Phone
+background.polycom670bg.bm.1.name.description=For Main Screen
+background.polycom670bg.bm.1.em.name.label=Background Expansion Module
+background.polycom670bg.bm.1.em.name.description=For first Expansion Module
+
+background.polycom450bg.label=Background Polycom SoundPoint IP 450
+background.polycom450bg.description=
+background.polycom450bg.enabled.label=Enable/Disable background configuration
+background.polycom450bg.enabled.description=This affects only the provisioning
+background.polycom450bg.selection.label=Selection
+background.polycom450bg.selection.description=
+background.polycom450bg.bm.1.name.label=Background Phone
+background.polycom450bg.bm.1.name.description=For Main Screen
+background.polycom450bg.bm.1.adj.label=Adjust
+background.polycom450bg.bm.1.adj.description=
 
 calendar.label=Calendar Integration
 calendar.description=This feature enables users to access and view their Microsoft Outlook calendar information directly from their phone. Users can also set up meetings, join meetings, and view meeting notifications from their phone.
@@ -2566,6 +2664,11 @@ prov.loginCredPwdFlushed.enabled.label=Flush password
 prov.loginCredPwdFlushed.enabled.description=If checked, when a user logs in or logs out, the login credential password is reset. If unchecked, the login credential password is not reset.
 prov.login.automaticLogout.label=Automatic log out
 prov.login.automaticLogout.description=The time (in minutes) before a non-default user is automatically logged out of the handset. If 0, the user is not automatically logged out.
+prov.serverType.set.label=Set Hoteling Server Type
+prov.serverType.set.description=
+prov.serverType.label=Hoteling Server Type Protocol
+prov.serverType.description=
+
 
 mwi.label=MWI
 mwi.backLight.disable.label=Backlight disable
@@ -2622,3 +2725,9 @@ homeScreen.doNotDisturb.enable.label=DND Icon
 softKey.label=SoftKeys
 softKey.feature.doNotDisturb.label=DND Softkey
 softKey.feature.doNotDisturb.description=Enable/Disable the DND softkey on the phone. Note: This parameter will work only when the feature EFK (Enhanced Feature Key) is enabled.
+
+softKey.feature.forward.label=Forward Softkey
+softKey.feature.forward.description=Enable/Disable the Forward softkey on the phone. Note: This parameter will work only when the feature EFK (Enhanced Feature Key) is enabled.
+
+softKey.feature.newcall.label=New Call Softkey
+softKey.feature.newcall.description=Enable/Disable the New Call softkey on the phone. Note: This parameter will work only when the feature EFK (Enhanced Feature Key) is enabled.

--- a/sipXpolycom/etc/polycom/phone-40.properties
+++ b/sipXpolycom/etc/polycom/phone-40.properties
@@ -2723,6 +2723,7 @@ homeScreen.forward.enable.label=Forward Icon
 homeScreen.doNotDisturb.enable.label=DND Icon
 
 softKey.label=SoftKeys
+softKey.feature.label=Features
 softKey.feature.doNotDisturb.label=DND Softkey
 softKey.feature.doNotDisturb.description=Enable/Disable the DND softkey on the phone. Note: This parameter will work only when the feature EFK (Enhanced Feature Key) is enabled.
 
@@ -2731,3 +2732,7 @@ softKey.feature.forward.description=Enable/Disable the Forward softkey on the ph
 
 softKey.feature.newcall.label=New Call Softkey
 softKey.feature.newcall.description=Enable/Disable the New Call softkey on the phone. Note: This parameter will work only when the feature EFK (Enhanced Feature Key) is enabled.
+
+softKey.efk.label=Enhanced Feature Keys
+softKey.efk.softKey.alignleft.label=Softkey Align left
+softKey.efk.softKey.alignleft.description=Use this parameter to left-align soft keys and remove blank soft keys from the order. By default, this parameter is disabled. Setting this parameter to 1 left-aligns soft keys and removes blank soft keys from the order. Note: This parameter does not work with custom soft keys.

--- a/sipXpolycom/etc/polycom/phone-4_5.xml
+++ b/sipXpolycom/etc/polycom/phone-4_5.xml
@@ -5574,16 +5574,24 @@
       </setting>
     </group>
     <group name="softKey" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
-	  <setting name="feature.doNotDisturb">
+      <group name="feature" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
+	  <setting name="doNotDisturb">
 		<type><boolean /></type>
 		<value>1</value>
 	  </setting>
-	  <setting name="feature.forward">
+	  <setting name="forward">
 		<type><boolean /></type>
 		<value>1</value>
 	  </setting>
-	  <setting name="feature.newcall">
+	  <setting name="newcall">
 		<type><boolean /></type>
 		<value>1</value>
 	  </setting>
+      </group>
+      <group name="efk" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
+	  <setting name="softKey.alignleft">
+		<type><boolean /></type>
+		<value>0</value>
+	  </setting>
+      </group>
     </group>

--- a/sipXpolycom/etc/polycom/phone-4_5.xml
+++ b/sipXpolycom/etc/polycom/phone-4_5.xml
@@ -55,13 +55,13 @@
         </type>
         <value>1</value>
       </setting>
-      <setting name="headsetmodeenabled" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="headsetmodeenabled" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
         <type>
           <boolean />
         </type>
         <value>1</value>
       </setting>
-      <setting name="handsetmodeenabled" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="handsetmodeenabled" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
         <type>
           <boolean />
         </type>
@@ -104,7 +104,7 @@
         <value>40</value>
       </setting>
     </group>
-    <group name="IdleViewPreferenceRemoteCalls" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="IdleViewPreferenceRemoteCalls" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <setting name="IdleViewPreferenceRemoteCalls">
         <type>
           <boolean />
@@ -113,7 +113,7 @@
       </setting>
     </group>
     <group name="numOfDisplayColumns" if="polycomVVX500||polycomVVX600">
-	    <setting name="numOfDisplayColumns" if="5.0.0||5.0.1||5.0.2||4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+	    <setting name="numOfDisplayColumns" if="5.0.0||5.0.1||5.0.2||4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 	    <type>
 	      <enum>
 	        <option>
@@ -165,7 +165,7 @@
         <value>15</value>
       </setting>
     </group>
-    <group name="em"  if="5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="em"  if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <setting name="smartpaging.enabled">
         <type>
           <boolean />
@@ -1731,7 +1731,7 @@
       </type>
       <value>86400</value>
     </setting>
-	<setting name="retryDnsPeriod" if="4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+	<setting name="retryDnsPeriod" if="4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <integer min="60" />
       </type>
@@ -1853,13 +1853,13 @@
       </type>
       <value>2222</value>
     </setting>
-    <setting name="videoPortRange.enable" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <setting name="videoPortRange.enable" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <boolean />
       </type>
       <value>0</value>
     </setting>
-    <setting name="videoPortRangeStart" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <setting name="videoPortRangeStart" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <integer min="1024" max="65486" />
       </type>
@@ -1879,7 +1879,7 @@
       </type>
       <value>0</value>
     </setting>
-    <setting name="sip.persistentConnection.enable" if="4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <setting name="sip.persistentConnection.enable" if="4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <boolean />
       </type>
@@ -2108,6 +2108,32 @@
       <value>1</value>
     </setting>
   </group>
+  <group name="auth">
+    <setting name="localAdminPassword.set">
+      <type>
+        <boolean />
+      </type>
+      <value>0</value>
+    </setting>
+    <setting name="localAdminPassword">
+      <type>
+        <string />
+      </type>
+      <value>4567</value>
+    </setting>
+    <setting name="localUserPassword.set">
+      <type>
+        <boolean />
+      </type>
+      <value>0</value>
+    </setting>
+    <setting name="localUserPassword">
+      <type>
+        <string />
+      </type>
+      <value>4567</value>
+    </setting>
+  </group>
   <group name="log">
     <group name="level.change" >
       <setting name="so">
@@ -2173,8 +2199,8 @@
       <setting name="poll" copy-of="so" unless="pre_3.2.0_model"/>
       <setting name="push" copy-of="so" unless="pre_3.2.0_model"/>
       <setting name="wmgr" copy-of="so" unless="pre_3.2.0_model"/>
-      <setting name="em" copy-of="so" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0"/>
-      <setting name="pwr" copy-of="so" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0"/>
+      <setting name="em" copy-of="so" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0"/>
+      <setting name="pwr" copy-of="so" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0"/>
     </group>
     <group name="device.syslog" advanced="yes">
       <setting name="serverName.set" hidden="yes">
@@ -2667,13 +2693,13 @@
       </type>
       <value>0</value>
     </setting>
-    <setting name="forward.enable" if="5.1.1||5.1.2||5.1.3||5.2.0">
+    <setting name="forward.enable" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <boolean />
       </type>
       <value>1</value>
     </setting>
-    <setting name="doNotDisturb.enable" if="5.1.1||5.1.2||5.1.3||5.2.0">
+    <setting name="doNotDisturb.enable" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <type>
         <boolean />
       </type>
@@ -2730,7 +2756,7 @@
         <value>1</value>
       </setting>
     </group>
-    <group name="idleRefresh" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="idleRefresh" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
     <setting name="onFailure">
         <type>
           <integer min="60" max="6553500"/>
@@ -2806,19 +2832,31 @@
         </type>
         <value>0</value>
       </setting>
+      <setting name="localProcessing.cf">
+        <type>
+          <boolean />
+        </type>
+        <value>1</value>
+      </setting>
       <setting name="dnd">
         <type>
           <boolean />
         </type>
         <value>0</value>
       </setting>
-      <setting name="callRecording" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="localProcessing.dnd">
+        <type>
+          <boolean />
+        </type>
+        <value>1</value>
+      </setting>
+      <setting name="callRecording" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
         <type>
           <boolean />
         </type>
         <value>0</value>
       </setting>
-      <setting name="securityClassification" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="securityClassification" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
         <type>
           <boolean />
         </type>
@@ -2894,7 +2932,7 @@
       </setting>
     </group>
     <group name="alertInfo">
-        <setting name="ignoreString" if="4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+        <setting name="ignoreString" if="4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
           <type>
             <string/>
           </type>
@@ -3327,7 +3365,7 @@
         </type>
         <value>1</value>
       </setting>
-      <setting name="etherModePC" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="etherModePC" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
         <type>
           <enum>
             <option><value>Disabled</value></option>
@@ -3842,7 +3880,7 @@
         <value>24800</value>
       </setting>
     </group>
-    <group name="ptt" if="4.0.X||4.1.X||4.1.0||4.1.2||4.1.3||4.1.4||4.1.5||4.1.6||4.1.7||4.1.8||5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="ptt" if="4.0.X||4.1.X||4.1.0||4.1.2||4.1.3||4.1.4||4.1.5||4.1.6||4.1.7||4.1.8||5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <setting name="address">
         <type>
 		  <string />
@@ -5212,7 +5250,14 @@
         <value></value>
       </setting>
     </group>
-    <group name="polycomVVX500bg" hidden="yes">
+  <group name="background">
+	<group name="polycomVVX300bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
       <setting name="selection">
         <type>
           <string />
@@ -5232,7 +5277,39 @@
         <value>ezLogo320x240.jpg</value>        
       </setting>
     </group>
-    <group name="polycomVVX600bg" hidden="yes">
+	<group name="polycomVVX500bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
+      <setting name="selection">
+        <type>
+          <string />
+        </type>
+        <value>2,1</value>        
+      </setting>
+      <setting name="bm.1.em.name">
+        <type>
+	      <string />
+	    </type>
+        <value>ezLogo320x240.jpg</value>        
+      </setting>
+       <setting name="bm.1.name">
+        <type>
+          <string />
+        </type>
+        <value>ezLogo320x240.jpg</value>        
+      </setting>
+    </group>
+    <group name="polycomVVX600bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
       <setting name="selection">
         <type>
           <string />
@@ -5252,7 +5329,13 @@
         <value>ezLogo800x480.jpg</value>        
       </setting>
     </group>
-    <group name="polycom550bg" hidden="yes">
+    <group name="polycom550bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
       <setting name="selection">
         <type>
           <string />
@@ -5278,7 +5361,13 @@
         <value>-6</value>        
       </setting>
     </group>
-    <group name="polycom670bg" hidden="yes">
+    <group name="polycom670bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
       <setting name="selection">
         <type>
           <string />
@@ -5298,7 +5387,13 @@
         <value>ezLogo320x160.jpg</value>
       </setting>
     </group>
-    <group name="polycom450bg" hidden="yes">
+    <group name="polycom450bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
       <setting name="selection">
         <type>
           <string />
@@ -5318,7 +5413,13 @@
         <value>-6</value>
       </setting>
     </group>
-    <group name="polycomVVX1500bg" hidden="yes">
+    <group name="polycomVVX1500bg" hidden="no">
+	  <setting name="enabled">
+		<type>
+		  <boolean />
+		</type>
+		<value>1</value>
+	  </setting>
       <setting name="selection">
         <type>
           <string />
@@ -5332,6 +5433,7 @@
         <value>ezLogo800x480.jpg</value>
       </setting>
     </group>
+  </group>
   <group name="e911" hidden="yes">
     <setting name="location">
       <type>
@@ -5357,7 +5459,7 @@
 	      </setting>
 	   </group>
     </group>
-    <group name="prov"  if="4.0.X||4.1.X||4.1.0||4.1.2||4.1.3||4.1.4||4.1.5||4.1.6||4.1.7||4.1.8||5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="prov"  if="4.0.X||4.1.X||4.1.0||4.1.2||4.1.3||4.1.4||4.1.5||4.1.6||4.1.7||4.1.8||5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <setting name="login.enabled">
 		<type><boolean /></type>
 		<value>0</value>
@@ -5377,6 +5479,37 @@
       <setting name="login.automaticLogout">
 		<type><integer min="0" max="46000"/></type>
 		<value>0</value>
+      </setting>
+      <setting name="serverType.set">
+		<type><boolean /></type>
+		<value>0</value>
+      </setting>
+      <setting name="serverType">
+		<type>
+                  <enum>
+                    <option>
+                      <label>FTP</label>
+                      <value>FTP</value>
+                    </option>
+                    <option>
+                      <label>TFTP</label>
+                      <value>TFTP</value>
+                    </option>
+                    <option>
+                      <label>HTTP</label>
+                      <value>HTTP</value>
+                    </option>
+                    <option>
+                      <label>HTTPS</label>
+                      <value>HTTPS</value>
+                    </option>
+                    <option>
+                      <label>FTPS</label>
+                      <value>FTPS</value>
+                    </option>
+                  </enum>
+                </type>
+		<value>HTTP</value>
       </setting>
     </group>      
 	<group name="mwi" if="5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3">
@@ -5406,43 +5539,51 @@
 		<value>1</value>
       </setting>
 	</group>
-	<group name="audioVideoToggle" if="5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0">
+	<group name="audioVideoToggle" if="5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
       <setting name="callMode.persistent">
 		<type><boolean /></type>
 		<value>1</value>
       </setting>
 	</group>
-	<group name="Diags" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+	<group name="Diags" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 	  <setting name="dumpcore.enabled">
 		<type><boolean /></type>
 		<value>0</value>
       </setting>
 	</group>
-    <group name="prov.autoConfigUpload" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="prov.autoConfigUpload" if="4.1.6||5.0.2||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 	  <setting name="enabled">
 		<type><boolean /></type>
 		<value>0</value>
       </setting>
 	</group>
-    <group name="lineKey" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0">
+    <group name="lineKey" if="4.1.6||4.1.7||4.1.8||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 	  <setting name="reassignment.enabled">
 		<type><boolean /></type>
 		<value>0</value>
       </setting>
 	</group>
-	<group name="homeScreen" if="5.1.1||5.1.2||5.1.3||5.2.0">
+	<group name="homeScreen" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 	  <setting name="forward.enable">
 		<type><boolean /></type>
 		<value>1</value>
       </setting>
-      <setting name="doNotDisturb.enable" if="5.1.1||5.1.2||5.1.3||5.2.0">
+      <setting name="doNotDisturb.enable" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 		<type><boolean /></type>
 		<value>1</value>
       </setting>
-	</group>
-	<group name="softKey" if="5.1.1||5.1.2||5.1.3||5.2.0">
+    </group>
+    <group name="softKey" if="5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
 	  <setting name="feature.doNotDisturb">
 		<type><boolean /></type>
 		<value>1</value>
-      </setting>
-	</group>
+	  </setting>
+	  <setting name="feature.forward">
+		<type><boolean /></type>
+		<value>1</value>
+	  </setting>
+	  <setting name="feature.newcall">
+		<type><boolean /></type>
+		<value>1</value>
+	  </setting>
+    </group>

--- a/sipXpolycom/etc/polycom/types.xml
+++ b/sipXpolycom/etc/polycom/types.xml
@@ -616,6 +616,12 @@
     <option><value>5.1.2</value></option>
     <option><value>5.1.3</value></option>
     <option><value>5.2.0</value></option>
+    <option><value>5.2.1</value></option>
+    <option><value>5.2.2</value></option>
+    <option><value>5.2.3</value></option>
+    <option><value>5.3.0</value></option>
+    <option><value>5.3.1</value></option>
+    <option><value>5.4.0</value></option>
   </enum>
 </type>
 <type id="ringtones">

--- a/sipXpolycom/etc/polycom/upload.xml
+++ b/sipXpolycom/etc/polycom/upload.xml
@@ -48,6 +48,12 @@
 		    <option><value>5.1.2</value></option>
 		    <option><value>5.1.3</value></option>
 		    <option><value>5.2.0</value></option>
+		    <option><value>5.2.1</value></option>
+		    <option><value>5.2.2</value></option>
+		    <option><value>5.2.3</value></option>
+		    <option><value>5.3.0</value></option>
+		    <option><value>5.3.1</value></option>
+		    <option><value>5.4.0</value></option>
         </enum>
     </type>
     <value>3.2.X</value>

--- a/sipXpolycom/src/org/sipfoundry/sipxconfig/phone/polycom/PolycomModel.java
+++ b/sipXpolycom/src/org/sipfoundry/sipxconfig/phone/polycom/PolycomModel.java
@@ -40,10 +40,16 @@ public final class PolycomModel extends PhoneModel {
     public static final DeviceVersion VER_5_1_2 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.1.2");
     public static final DeviceVersion VER_5_1_3 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.1.3");
     public static final DeviceVersion VER_5_2_0 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.2.0");
+    public static final DeviceVersion VER_5_2_1 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.2.1");
+    public static final DeviceVersion VER_5_2_2 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.2.2");
+    public static final DeviceVersion VER_5_2_3 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.2.3");
+    public static final DeviceVersion VER_5_3_0 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.3.0");
+    public static final DeviceVersion VER_5_3_1 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.3.1");
+    public static final DeviceVersion VER_5_4_0 = new DeviceVersion(PolycomPhone.BEAN_ID, "5.4.0");
     public static final DeviceVersion[] SUPPORTED_VERSIONS = new DeviceVersion[] {
         VER_3_1_X, VER_3_2_X, VER_4_0_X, VER_4_1_X, VER_4_1_0, VER_4_1_2, VER_4_1_3, VER_4_1_4, VER_4_1_5,
         VER_5_0_0, VER_5_0_1, VER_5_0_2, VER_4_1_6, VER_4_1_7, VER_4_1_8, VER_5_1_1, VER_5_1_2, VER_5_1_3,
-        VER_5_2_0
+        VER_5_2_0, VER_5_2_1, VER_5_2_2, VER_5_2_3, VER_5_3_0, VER_5_3_1, VER_5_4_0
     };
     private static final Log LOG = LogFactory.getLog(PolycomModel.class);
     private DeviceVersion m_deviceVersion;

--- a/sipXpolycom/src/sipxplugin.beans.xml
+++ b/sipXpolycom/src/sipxplugin.beans.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
   <bean id="polycomModel" parent="abstractPhoneModel" class="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel"
     abstract="true" >
-	<property name="vendor" value="Polycom"/>
+    <property name="vendor" value="Polycom"/>
     <property name="restartSupported" value="true" />
   </bean>
 
@@ -47,6 +47,19 @@
     class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
   <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"
     class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+  <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"
+    class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+  <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"
+    class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+  <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"
+    class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+  <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"
+    class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+  <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"
+    class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+  <bean id="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"
+    class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean" />
+    
 
   <bean id="polycom300" parent="polycomModel">
    <property name="label" value="Polycom SoundPoint IP 300" />
@@ -465,6 +478,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">
@@ -589,6 +608,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">
@@ -630,6 +655,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">
@@ -668,6 +699,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">
@@ -706,6 +743,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">
@@ -744,6 +787,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">
@@ -782,6 +831,12 @@
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_2"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_1_3"/>
         <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_2"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_2_3"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_0"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_3_1"/>
+        <ref local="org.sipfoundry.sipxconfig.phone.polycom.PolycomModel.VER_5_4_0"/>
       </list>
     </property>
     <property name="defaultVersion">


### PR DESCRIPTION
I have implemented some configuration features (wished by our customers) to the polycom configuration plugin.

Added ACD Agent login-logout
Added admin and user password configuration
Added labels for Polycom firmware 5.2.1, 5.2.2, 5.2.3, 5.3.0, 5.3.1, 5.4.0
Added configuration for local processing of DND and FWD, when server-based feature control is active
Making device backgrounds editable (SoundPoint and VVX series) with enable/disable feature

Tested with 15.10 and VVX 300/310/410/500
