### PR TITLE
[SIPX-242] Gateway settings - keep display name when transforming extension

### DIFF
--- a/sipXproxy/lib/authplugins/CallerAlias.cpp
+++ b/sipXproxy/lib/authplugins/CallerAlias.cpp
@@ -212,7 +212,7 @@ CallerAlias::authorizeAndModify(const UtlString& id,    /**< The authenticated i
 
             // look up any caller alias for this identity and contact domain
             UtlString callerAlias;
-            if (identityIsLocal && getCallerAlias(callerIdentity, targetDomain, callerAlias) )
+            if (identityIsLocal && getCallerAlias(callerIdentity, targetDomain, originalFromField, callerAlias) )
             {
                // found a caller alias, so rewrite the From information
                /*
@@ -362,6 +362,7 @@ static std::string string_right(const std::string& str, size_t size)
 bool CallerAlias::getCallerAlias (
   const UtlString& identity,
   const UtlString& domain,
+  const UtlString& fromField,
   UtlString& callerAlias_
 ) const
 {
@@ -407,7 +408,18 @@ bool CallerAlias::getCallerAlias (
                 userId = userId = buff;
             }
 
-            callerAlias = "<sip:";
+            // Preserve the Display Name portion of the original From header if possible
+            // Transforming the extension is commonly used to send calls to attached PBX or similar
+            size_t uriLoc = fromField.str().find("<");
+            if (uriLoc != std::string::npos && uriLoc > 0)
+            {
+                callerAlias = fromField.str().substr(0, uriLoc) + "<sip:";
+            }
+            else
+            {
+                callerAlias = "<sip:";
+            }
+
             callerAlias += userId;
             callerAlias += identity.str().substr(loc);
             callerAlias += ">";

--- a/sipXproxy/lib/authplugins/CallerAlias.h
+++ b/sipXproxy/lib/authplugins/CallerAlias.h
@@ -116,6 +116,7 @@ class CallerAlias : public AuthPlugin
       const UtlString& identity, ///< identity of caller in 'user@domain' form (no scheme)
       const UtlString& domain,   /**< domain and optional port for target
                                   *  ( 'example.com' or 'example.com:5099' ) */
+      const UtlString& fromField,// original SIP From field
       UtlString& callerAlias     /// returned alias
                         ) const;
    


### PR DESCRIPTION
The main purpose for this is for better integration when sending calls to another PBX.
