### PR TITLE
Revert "SIPX-61 Mobile forwarding CDR problem"

### DIFF
--- a/sipXproxy/src/SipXProxyCseObserver.cpp
+++ b/sipXproxy/src/SipXProxyCseObserver.cpp
@@ -32,6 +32,7 @@
 const int SipXProxyCallStateFlushInterval = 20; /* seconds */
 const int SipXProxyCallStateCleanupInterval = 60 * 30; /* 60 seconds * 30 = 30 minutes */
 
+
 class BranchTimePair : public UtlString
 {
 
@@ -370,7 +371,7 @@ UtlBoolean SipXProxyCseObserver::handleMessage(OsMsg& eventMessage)
             {
                if (toTag.isNull())
                {
-                  sipMsg->getContactEntry(0, &contact);
+                  sipMsg->getContactEntry(0, &contact);               
                   thisMsgIs = aCallRequest;
                }
             }
@@ -401,8 +402,8 @@ UtlBoolean SipXProxyCseObserver::handleMessage(OsMsg& eventMessage)
                   // purposes.  If not dialog-forming, then any final response above 400
                   // except 401 Unauthorized, 407 Proxy Authentication Required and 
                   // 408 Request Timeout will terminate.  If we're in a dialog then
-                  // only 408 (Request Timeout) and 481 (Call/Transaction does not exist)
-                  // will terminate the dialog.
+            	  // only 408 (Request Timeout) and 481 (Call/Transaction does not exist)
+            	  // will terminate the dialog.
 
                   rspStatus = sipMsg->getResponseStatusCode();
                   if (rspStatus >= SIP_4XX_CLASS_CODE) // any failure
@@ -417,28 +418,6 @@ UtlBoolean SipXProxyCseObserver::handleMessage(OsMsg& eventMessage)
                   {
                      thisMsgIs = aCallSetup;
                      sipMsg->getContactEntry(0, &contact);
-
-                     // CDR problem while local phone is forwarded to mobile phone.
-                     // SipMsg has transaction. While, sipTransaction request uri has a value "AL" that
-                     // informs about forwarded call. This uri added to hash map with session call id.
-                     // And this uri used instead of contact value when call setup event is processing
-
-                     SipTransaction* pTransaction = sipMsg->getSipTransaction();
-
-                     if (pTransaction)
-                     {
-                         UtlString headerCallDest;
-                         UtlString inviteUriStr(pTransaction->getRequestUri());
-                         Url inviteUri(inviteUriStr, Url::AddrSpec);
-                         inviteUri.getUrlParameter(SIP_SIPX_CALL_DEST_FIELD, headerCallDest, 0);
-
-                         if (headerCallDest == "AL")
-                         {
-                             UtlString callId;
-                             sipMsg->getCallIdField(&callId);
-                             mCallIdRequiestUriMap.insertKeyAndValue(new UtlString(callId), new UtlString(pTransaction->getRequestUri()));
-                         }
-                     }
                   }
                }
                else
@@ -589,7 +568,6 @@ UtlBoolean SipXProxyCseObserver::handleMessage(OsMsg& eventMessage)
                         // with this info. Otherwise skip over.
                         if ( paiPresent ) {
                            callIdBranchIdTime = (BranchTimePair*) mCallTransMap.findValue(&callId);
-
                            if ( callIdBranchIdTime && (*callIdBranchIdTime->getPaiPresent() == false) ) {
                               // need to generate another call request event in order to state originator is internal.
                               callIdBranchIdTime->setPaiPresent(&paiPresent);
@@ -606,7 +584,6 @@ UtlBoolean SipXProxyCseObserver::handleMessage(OsMsg& eventMessage)
                            return(TRUE);
                         }
                      }
-
                      mCallTransMutex.release();
                   }
 
@@ -637,19 +614,7 @@ UtlBoolean SipXProxyCseObserver::handleMessage(OsMsg& eventMessage)
                         routeFound = true;
                      }
                   }
-
-                  {
-                     UtlString* pUrlMappingCdrStr = dynamic_cast<UtlString*>(mCallIdRequiestUriMap.findValue(&callId));
-
-                     if (pUrlMappingCdrStr && pUrlMappingCdrStr->data()) {
-                         mpBuilder->callSetupEvent(mSequenceNumber, timeNow, *pUrlMappingCdrStr, calleeRoute, branchId, viaCount);
-                         mCallIdRequiestUriMap.destroy(&callId);
-                     }
-                     else
-                     {
-                         mpBuilder->callSetupEvent(mSequenceNumber, timeNow, contact, calleeRoute, branchId, viaCount);
-                     }
-                  }
+                  mpBuilder->callSetupEvent(mSequenceNumber, timeNow, contact, calleeRoute, branchId, viaCount);
                   break;
    
                case aCallFailure:

--- a/sipXproxy/src/SipXProxyCseObserver.h
+++ b/sipXproxy/src/SipXProxyCseObserver.h
@@ -83,12 +83,7 @@ private:
    SipXProxyCseObserver operator=(const SipXProxyCseObserver& rSipXProxyCseObserver);
 
    static void CleanupTransMap(void* userData, const intptr_t eventData);
-
-   // When local phone is forwarded to mobile phone, it is CDR information is problematical.
-   // Use Hash map structure for hide forwarding call request uri with its session call id.
-   UtlHashMap mCallIdRequiestUriMap;
 };
-
 
 /* ============================ INLINE METHODS ============================ */
 

--- a/sipXtackLib/include/net/SipTransaction.h
+++ b/sipXtackLib/include/net/SipTransaction.h
@@ -334,8 +334,6 @@ public:
     // Set the data to be used to generate a Reason header for any CANCEL
     // generated for any child transaction.
 
-    UtlString &getRequestUri(void) const;
-
     UtlSList& childTransactions();
 
     bool isMarkedForDeletion() const;

--- a/sipXtackLib/src/net/SipTransaction.cpp
+++ b/sipXtackLib/src/net/SipTransaction.cpp
@@ -6162,11 +6162,6 @@ void SipTransaction::setCancelReasonValue(const char* protocol,
    }
 }
 
-UtlString &SipTransaction::getRequestUri() const
-{
-   return mRequestUri;
-}
-
 //: Determine best choice for protocol, based on message size
 //  Default is UDP, returns TCP only for large messages
 OsSocket::IpProtocolSocketType SipTransaction::getPreferredProtocol()


### PR DESCRIPTION
Reverts sipXcom/sipxecs#30
Fails to build with

net/SipTransaction.cpp: In member function 'UtlString& SipTransaction::getRequestUri() const':
net/SipTransaction.cpp:6167: error: invalid initialization of reference of type 'UtlString&' from expression of type 'const UtlString'
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-unused-result"
make[3]: **\* [libsipXtack_la-SipTransaction.lo] Error 1

Please correct this

Thanks!
