### PR TITLE
[SIPX-442] Changed parameter inside Polycom Hoteling configuration

### DIFF
--- a/sipXpolycom/etc/polycom/mac-address.d.40/site.cfg.vm
+++ b/sipXpolycom/etc/polycom/mac-address.d.40/site.cfg.vm
@@ -374,14 +374,21 @@ sec.TLS.profile.1.caCert.platform2="0"
 />
 #end
 
-#set ($prov = $cfg.EndpointSettings.getSetting('prov'))
-#if($prov)
+
+#set ($prov_login = $cfg.EndpointSettings.getSetting('prov').getSetting('prov_login'))
+#if($prov_login)
 <prov
-#foreach ($setting in $cfg.getRecursiveSettings($prov))
+#foreach ($setting in $cfg.getRecursiveSettings($prov_login))
           prov.${setting.ProfileName}="$!{setting.Value}"
 #end
-/>
 #end
+#set ($prov_device = $cfg.EndpointSettings.getSetting('prov').getSetting('prov_device'))
+#if($prov_device)
+#foreach ($setting in $cfg.getRecursiveSettings($prov_device))
+          device.prov.${setting.ProfileName}="$!{setting.Value}"
+#end
+#end
+/>
 
 #set ($keyboard = $cfg.EndpointSettings.getSetting('keyboard'))
 #if($keyboard)

--- a/sipXpolycom/etc/polycom/phone-40.properties
+++ b/sipXpolycom/etc/polycom/phone-40.properties
@@ -2667,20 +2667,22 @@ ptt.groupPaging.pageMode.group.25.subscribed.description=Subscribe the phone to 
 prov.label=Hoteling
 prov.description=The Hoteling (User Profiles) feature enables users to access their personal phone settings from any phone in the organization.
 
-prov.login.enabled.label=Enabled
-prov.login.enabled.description=
-prov.login.persistent.label=Persistent
-prov.login.persistent.description=If unchecked, users are logged out if the handset reboots. If checked, users remain logged in when the phone reboots.
-prov.login.required.label=Login required
-prov.login.required.description=If checked, a user must log in when the login feature is enabled. If uncheked, the user does not have to log in.
-prov.loginCredPwdFlushed.enabled.label=Flush password
-prov.loginCredPwdFlushed.enabled.description=If checked, when a user logs in or logs out, the login credential password is reset. If unchecked, the login credential password is not reset.
-prov.login.automaticLogout.label=Automatic log out
-prov.login.automaticLogout.description=The time (in minutes) before a non-default user is automatically logged out of the handset. If 0, the user is not automatically logged out.
-prov.serverType.set.label=Set Hoteling Server Type
-prov.serverType.set.description=
-prov.serverType.label=Hoteling Server Type Protocol
-prov.serverType.description=
+prov.prov_login.label=Login Provisioning
+prov.prov_login.login.enabled.label=Enabled
+prov.prov_login.login.enabled.description=
+prov.prov_login.login.persistent.label=Persistent
+prov.prov_login.login.persistent.description=If unchecked, users are logged out if the handset reboots. If checked, users remain logged in when the phone reboots.
+prov.prov_login.login.required.label=Login required
+prov.prov_login.login.required.description=If checked, a user must log in when the login feature is enabled. If uncheked, the user does not have to log in.
+prov.prov_login.loginCredPwdFlushed.enabled.label=Flush password
+prov.prov_login.loginCredPwdFlushed.enabled.description=If checked, when a user logs in or logs out, the login credential password is reset. If unchecked, the login credential password is not reset.
+prov.prov_login.login.automaticLogout.label=Automatic log out
+prov.prov_login.login.automaticLogout.description=The time (in minutes) before a non-default user is automatically logged out of the handset. If 0, the user is not automatically logged out.
+prov.prov_device.label=Provisioning Type
+prov.prov_device.serverType.set.label=Set Hoteling Server Type
+prov.prov_device.serverType.set.description=
+prov.prov_device.serverType.label=Hoteling Server Type Protocol
+prov.prov_device.serverType.description=
 
 
 mwi.label=MWI

--- a/sipXpolycom/etc/polycom/phone-4_5.xml
+++ b/sipXpolycom/etc/polycom/phone-4_5.xml
@@ -5504,7 +5504,8 @@
 	   </group>
     </group>
     <group name="prov"  if="4.0.X||4.1.X||4.1.0||4.1.2||4.1.3||4.1.4||4.1.5||4.1.6||4.1.7||4.1.8||5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3||5.2.0||5.2.1||5.2.2||5.2.3||5.3.0||5.3.1||5.4.0">
-      <setting name="login.enabled">
+      <group name="prov_login">
+	  <setting name="login.enabled">
 		<type><boolean /></type>
 		<value>0</value>
       </setting>
@@ -5524,6 +5525,8 @@
 		<type><integer min="0" max="46000"/></type>
 		<value>0</value>
       </setting>
+      </group>
+	  <group name="prov_device">
       <setting name="serverType.set">
 		<type><boolean /></type>
 		<value>0</value>
@@ -5555,6 +5558,7 @@
                 </type>
 		<value>HTTP</value>
       </setting>
+	  </group>
     </group>      
 	<group name="mwi" if="5.0.0||5.0.1||5.0.2||5.1.1||5.1.2||5.1.3">
       <setting name="backLight.disable">


### PR DESCRIPTION
Provisioning Server Type has no effect
Splitted Hoteling configuration in two sub-groups to manage different parameter names
