### PR TITLE
SIPX-132:  When using DID aliases, the registrar signs the 302 contac…

### DIFF
--- a/sipXproxy/lib/authplugins/EnforceAuthRules.cpp
+++ b/sipXproxy/lib/authplugins/EnforceAuthRules.cpp
@@ -269,9 +269,10 @@ EnforceAuthRules::authorizeAndModify(const UtlString& id,    /**< The authentica
             }
             else
             {
+              result = DENY;
+
               if (!unmatchedPermissions.isNull())
               {
-                result = DENY;
                 Os::Logger::instance().log(FAC_AUTH, PRI_WARNING,
                               "EnforceAuthRules[%s]::authorizeAndModify "
                               " call '%s' requires '%s'",
@@ -284,9 +285,8 @@ EnforceAuthRules::authorizeAndModify(const UtlString& id,    /**< The authentica
               }
               else
               {
-                result = ALLOW;
                 Os::Logger::instance().log(FAC_AUTH, PRI_DEBUG, "EnforceAuthRules[%s]::authorizeAndModify "
-                             " id '%s' authorized by 'no permission required'",
+                             " id '%s' is not authorized, unmatchedPermissions is empty",
                              mInstanceName.data(), id.data());
               }
             }

--- a/sipXregistry/lib/redirect_plugins/SipRedirectorAliasDB.cpp
+++ b/sipXregistry/lib/redirect_plugins/SipRedirectorAliasDB.cpp
@@ -228,10 +228,6 @@ SipRedirectorAliasDB::lookUp(
         //
         authIdentity.setIdentity(userIdentity);
       }
-      else
-      {
-        authIdentity.setIdentity(requestIdentity);
-      }
 
       for (EntityDB::Aliases::iterator iter = aliases.begin(); iter != aliases.end(); iter++)
       {


### PR DESCRIPTION
…t with the identity of the alias instead of the real user account resulting to authentication failure in the proxy
- after review fixes
