### PR TITLE
Adding new ring types

### DIFF
--- a/sipXyealink/etc/yealink/line-8X.xml
+++ b/sipXyealink/etc/yealink/line-8X.xml
@@ -62,7 +62,7 @@
 	<setting name="auto_answer"><type><boolean/></type><value>0</value></setting>
 	<!-- Assign a ringtone for account 1. The system ring tones are: common.wav (default), Ring1.wav, Ring2.wav-->
 	<!-- You can configure the custom ring tone (Family.wav) for the account 1, the value format is: account.1.ringtone.ring_type = Family.wav-->
-	<setting name="ringtone.ring_type"><type refid="yealink_ring_type"/><value>common</value></setting>
+	<setting name="ringtone.ring_type"><type refid="yealink_account_ring_type"/><value>common</value></setting>
 	<!-- Enables or disables the ACD feature for account X. -->
 	<setting name="acd.enable"><type><boolean/></type><value>0</value></setting>
 	<!-- Enables or disables the IP phone to display the available or unavailable soft key after the phone logs into the ACD system. -->


### PR DESCRIPTION
Adding new Ring types according to yealink configuration parameters V8
Example:
account.1.ringtone.ring_type = Ring3.wav
It means configuring Ring3.wav for account1.
account.1.ringtone.ring_type = Common
It means account1 will use the ring tone selected for the IP phone configured by the parameter "phone_setting.ring_type".
