### PR TITLE
SIPX-529

### DIFF
--- a/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/commserver/imdb/SpeedDials.java
+++ b/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/commserver/imdb/SpeedDials.java
@@ -73,8 +73,8 @@ public class SpeedDials extends AbstractDataSetGenerator {
                 List<Button> buttons = speedDial.getButtons();
                 for (Button button : buttons) {
                     //do not allow presence subscriptions to self
-                    if (!m_speedDialManager.isAllowSubscriptionToSelf()
-                            && (!button.isBlf() || user.equals(button.getNumber()))) {
+                    if (!button.isBlf() || (!m_speedDialManager.isAllowSubscriptionToSelf()
+                            && user.equals(button.getNumber()))) {
                         continue;
                     }
                     DBObject buttonDBO = new BasicDBObject();


### PR DESCRIPTION
Allow to self should only override name check for BLF, not BLF/Speed dial check