### PR TITLE
SIPX-608

### DIFF
--- a/sipXpolycom/etc/polycom/line-4_5.xml
+++ b/sipXpolycom/etc/polycom/line-4_5.xml
@@ -24,7 +24,7 @@
       </type>
       <value />
     </setting>
-    <setting name="useTelUriAsLineLabel" if="4.1.8">
+    <setting name="useTelUriAsLineLabel" if="4.1.8||5.3.1||5.4.0||5.4.1||5.4.3">
       <type>
         <boolean />
       </type>


### PR DESCRIPTION
add availability for "useTelUriAsLabel" paramter for polycom FW 5.3.1, 5.4.0, 5.4.1, 5.4.3