### PR TITLE
UC-4383 Fix for activecdrs in sipxconfig

### DIFF
--- a/sipXcdr/lib/rest/active_cdrs.rb
+++ b/sipXcdr/lib/rest/active_cdrs.rb
@@ -28,6 +28,7 @@ class ActiveCdrs < WEBrick::HTTPServlet::AbstractServlet
     end
 
     resp.body="#{doc}"
+    resp["Content-Type"] = 'text/xml; charset=UTF-8'
     raise WEBrick::HTTPStatus::OK
   end
 

--- a/sipXcdr/sipxcallresolver.wsdl
+++ b/sipXcdr/sipxcallresolver.wsdl
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="urn:CdrService"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:si="http://soapinterop.org/xsd"

--- a/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/ActiveCallREST.java
+++ b/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/ActiveCallREST.java
@@ -1,0 +1,40 @@
+package org.sipfoundry.sipxconfig.cdr;
+
+/**
+ * Maps Active call retrieved from callresolver active calls REST service
+ */
+public class ActiveCallREST {
+    private final String m_from;
+    private final String m_to;
+    private final String m_recipient;
+    private final long m_startTime;
+    private final long m_duration;
+
+    public ActiveCallREST(String from, String to, String recipient, long startTime, long duration) {
+        m_from = from;
+        m_to = to;
+        m_recipient = recipient;
+        m_startTime = startTime;
+        m_duration = duration;
+    }
+
+    public String getFrom() {
+        return m_from;
+    }
+
+    public String getTo() {
+        return m_to;
+    }
+
+    public String getRecipient() {
+        return m_recipient;
+    }
+
+    public long getStartTime() {
+        return m_startTime;
+    }
+
+    public long getDuration() {
+        return m_duration;
+    }
+}

--- a/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/CdrManagerImpl.java
+++ b/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/CdrManagerImpl.java
@@ -586,46 +586,6 @@ public class CdrManagerImpl extends JdbcDaoSupport implements CdrManager, Featur
         }
     }
 
-    /**
-     * Maps Active call retrieved from callresolver active calls REST service
-     */
-    private class ActiveCallREST {
-        private final String m_from;
-        private final String m_to;
-        private final String m_recipient;
-        private final long m_startTime;
-        private final long m_duration;
-
-        public ActiveCallREST(String from, String to, String recipient, long startTime, long duration) {
-            m_from = from;
-            m_to = to;
-            m_recipient = recipient;
-            m_startTime = startTime;
-            m_duration = duration;
-        }
-
-        public String getFrom() {
-            return m_from;
-        }
-
-        public String getTo() {
-            return m_to;
-        }
-
-        public String getRecipient() {
-            return m_recipient;
-        }
-
-        public long getStartTime() {
-            return m_startTime;
-        }
-
-        public long getDuration() {
-            return m_duration;
-        }
-
-    }
-
     @Override
     public Collection<GlobalFeature> getAvailableGlobalFeatures(FeatureManager featureManager) {
         return null;

--- a/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/CdrManagerImpl.java
+++ b/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/CdrManagerImpl.java
@@ -292,7 +292,7 @@ public class CdrManagerImpl extends JdbcDaoSupport implements CdrManager, Featur
     private String getActiveCdrsRestUrl(User user) {
         Address address = getCdrAgentAddress();
         if (null == user) {
-            return String.format("http://%s:%d/activecdrs?name=%s", address.getAddress(), address.getPort());
+            return String.format("http://%s:%d/activecdrs", address.getAddress(), address.getPort());
         } else {
             return String.format("http://%s:%d/activecdrs?name=%s", address.getAddress(), address.getPort(),
                 user.getUserName());

--- a/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/CdrManagerImpl.java
+++ b/sipXconfig/neoconf/src/org/sipfoundry/sipxconfig/cdr/CdrManagerImpl.java
@@ -589,7 +589,7 @@ public class CdrManagerImpl extends JdbcDaoSupport implements CdrManager, Featur
     /**
      * Maps Active call retrieved from callresolver active calls REST service
      */
-    static class ActiveCallREST {
+    private class ActiveCallREST {
         private final String m_from;
         private final String m_to;
         private final String m_recipient;


### PR DESCRIPTION
Switched from old SOAP service to newer REST Service. this works with UTF-8 encoded characters without problems.

Now activecalls don't break anymore if user displayname includes UTF-8 characters. This works also in every API based call.