### PR TITLE
SIPX-641 - profile XML errors

### DIFF
--- a/sipXgrandstream/etc/grandstream/line.xml
+++ b/sipXgrandstream/etc/grandstream/line.xml
@@ -709,7 +709,7 @@
             </type>
             <value>0</value>
         </setting>
-        <setting name="26049-P26149-P26249-P26349-P26449-P26549" if="gsPhoneGxp21(30|35|40|60|70)">
+        <setting name="P26049-P26149-P26249-P26349-P26449-P26549" if="gsPhoneGxp21(30|35|40|60|70)">
             <label>Prefix for dialing password</label>
             <type>
                 <string/>

--- a/sipXgrandstream/etc/grandstream/phone.xml
+++ b/sipXgrandstream/etc/grandstream/phone.xml
@@ -1533,7 +1533,7 @@
             <value></value>
             <description></description>
         </setting>
-        <setting name="#P9904" if="gsPhoneGxp21(30|35|40|60|70)">
+        <setting name="P9904" if="gsPhoneGxp21(30|35|40|60|70)">
             <label>OpenVPN Client Key</label>
             <type>
                 <string/>


### PR DESCRIPTION
Grandstream GXP 2160 phone  bug '#' on the parameter name