### PR TITLE
UC-4761: Updated sipx-dbutil to work on Mongo SECONDARY

### DIFF
--- a/sipXtools/src/sipx-dbutil
+++ b/sipXtools/src/sipx-dbutil
@@ -606,7 +606,7 @@ if __name__ == '__main__':
 	if test_flag:
 		client = pymongo.Connection('192.168.0.39', 27017)	# remote testing
 	else:
-		client = pymongo.Connection('localhost', 27017, slaveOk=True)
+		client = pymongo.Connection('localhost', 27017, readPreference="secondaryPreferred")
 			
 	
 		


### PR DESCRIPTION
using new readPreference="secondaryPreferred" instead of slaveOk=True

UC-4761