### PR TITLE
UC-4769: Change block size in TFTP service to 1300

### DIFF
--- a/sipXconfig/etc/tftp.cf
+++ b/sipXconfig/etc/tftp.cf
@@ -36,7 +36,7 @@ bundle agent tftp_config {
 
 bundle edit_line tftp_xinet_config {
   vars:
-    "rootdir" string => "$(sipx.SIPX_VARDIR)/configserver/phone/profile/tftproot";
+    "rootdir" string => "$(sipx.SIPX_VARDIR)/configserver/phone/profile/tftproot --blocksize 1300";
     tftp::
       "disable" string => "no";
     !tftp::


### PR DESCRIPTION
UC-4769: Change block size in TFTP service to 1300 bytes