### PR TITLE
SIPX-788: sipxecs-setup crashes if FQDN hostname is not set

### DIFF
--- a/sipXsupervisor/bin/sipxecs-setup.in
+++ b/sipXsupervisor/bin/sipxecs-setup.in
@@ -410,6 +410,7 @@ class Network
     x = `hostname -d 2>/dev/null`.chomp
     if $? == 0 && ! x.empty?
       domain_from_hostname_d = x
+    else domain_from_hostname_d = "localdomain"
     end    
 
     File.open('/etc/hosts', 'r') {|f|


### PR DESCRIPTION
On CentOS 7, /etc/sysconfig/network is empty by default, leaving sipxecs-setup with null domain value. The fix ensures that "localdomain" default is set if no other domain is acquired from system config.