### PR TITLE
SIPX-811: Update Audiocodes INI to make fax work

### DIFF
--- a/sipXaudiocodes/etc/audiocodes/gateway.xml
+++ b/sipXaudiocodes/etc/audiocodes/gateway.xml
@@ -102,7 +102,7 @@
           </option>
         </enum>
       </type>
-      <value>1</value>
+      <value>0</value>
     </setting>
     <setting name="ChannelSelectMode" unless="digital" advanced="yes">
       <type>
@@ -186,7 +186,7 @@
           </option>
         </enum>
       </type>
-      <value>3</value>
+      <value>0</value>
     </setting>
     <setting name="DetFaxOnAnswerTone" advanced="yes">
       <type>
@@ -1776,7 +1776,7 @@
             </option>
           </enum>
         </type>
-        <value>1</value>
+        <value>0</value>
       </setting>
       <setting name="FaxModemBypassCoderType">
         <type>


### PR DESCRIPTION
Disables fax options in Audiocodes INI and disables PRACK