### PR TITLE
UC-4832: mongod.log doesn't seem to rotate

### DIFF
--- a/sipXsupervisor/etc/logrotate.cf
+++ b/sipXsupervisor/etc/logrotate.cf
@@ -99,7 +99,6 @@ $(sipx.SIPX_LOGDIR)/firewall/*.log {
     create 644 mongod mongod
     daily
     rotate 30
-    size 50M
     compress
     dateext
     missingok


### PR DESCRIPTION
Removed size so Mongo log rotates daily