### PR TITLE
SIPX-825: Fix CFengine promises

### DIFF
--- a/sipXconfig/etc/mongodb.cf
+++ b/sipXconfig/etc/mongodb.cf
@@ -580,7 +580,7 @@ bundle agent mongodb_client {
       # absolutely nec..  So sipXconfig should take care the client config
       # file it generates has the same checksum as the original or not generate
       # ini file in cfdata unless it's different.
-      "$(sipx.SIPX_CONFDIR)/mongo-client.ini",
+      "$(sipx.SIPX_CONFDIR)/mongo-client.ini"
         comment => "install mongo client config $(this.promiser)",
         create => "true",
         perms => m("644"),
@@ -588,7 +588,7 @@ bundle agent mongodb_client {
         classes => if_repaired("mongo_client_reconnect");
 
     mongo_local::
-      "$(sipx.SIPX_CONFDIR)/mongo-local.ini",
+      "$(sipx.SIPX_CONFDIR)/mongo-local.ini"
         comment => "local mongo db $(this.promiser)",
         create => "true",
         perms => m("644"),
@@ -597,7 +597,7 @@ bundle agent mongodb_client {
         classes => if_repaired("mongo_local_reconnect");
 
     !mongo_local::
-      "$(sipx.SIPX_CONFDIR)/mongo-local.ini",
+      "$(sipx.SIPX_CONFDIR)/mongo-local.ini"
         comment => "do not use local mongo db $(this.promiser)",
         delete => unlink,
         classes => if_repaired("mongo_local_reconnect");
@@ -613,7 +613,7 @@ bundle agent mongodb_initialize {
 
   files:
     !has_config::
-      "$(config)",
+      "$(config)"
         comment => "Create initial mongo cluster db model $(this.promiser)",
         create => "true",
         perms => mog("644", "$(sipx.SIPXPBXUSER)", "$(sipx.SIPXPBXGROUP)"),

--- a/sipXconfig/etc/zz_apache.cf
+++ b/sipXconfig/etc/zz_apache.cf
@@ -174,7 +174,7 @@ bundle agent verify_httpd_user(user,password) {
       create => "true";
 
   commands:
-    "/usr/bin/htpasswd",
+    "/usr/bin/htpasswd"
       comment => "Creating apache user $(user)",
       args => "-b $(sipx.APACHE2_CONFDIR)/provusers.tmp $(user) $(password)";
 }

--- a/sipXsupervisor/etc/cfengine_stdlib.cf
+++ b/sipXsupervisor/etc/cfengine_stdlib.cf
@@ -221,7 +221,7 @@ field_edits:
 
 insert_lines:
 
-  "$(index)=$($(v)[$(index)])",
+  "$(index)=$($(v)[$(index)])"
 
          comment => "Insert a variable definition",
       ifvarclass => "!$(cindex[$(index)])_in_file";
@@ -245,7 +245,7 @@ classes:
 
 insert_lines:
 
-  "$($(v)[$(index)])",
+  "$($(v)[$(index)])"
 
          comment => "Append users into a password file format",
       ifvarclass => "add_$(index)";
@@ -269,7 +269,7 @@ classes:
 
 insert_lines:
 
-  "$($(v)[$(index)])",
+  "$($(v)[$(index)])"
 
          comment => "Append users into a group file format",
       ifvarclass => "add_$(index)";

--- a/sipXsupervisor/etc/sipx.cf.in
+++ b/sipXsupervisor/etc/sipx.cf.in
@@ -293,10 +293,10 @@ bundle agent rh_chkconfig_status(s){
 
   reports:
     all::
-      "${g.pf} Service ${s} is enabled",
+      "${g.pf} Service ${s} is enabled"
         ifvarclass => "${s}_enabled";
 
-      "${g.pk} Service ${s} is not enabled",
+      "${g.pk} Service ${s} is not enabled"
         ifvarclass => "!${s}_enabled";
 }
 
@@ -309,10 +309,10 @@ bundle agent rh_systemctl_status(s){
 
   reports:
     all::
-      "${g.pf} Service ${s} is enabled",
+      "${g.pf} Service ${s} is enabled"
         ifvarclass => "${s}_enabled";
 
-      "${g.pk} Service ${s} is not enabled",
+      "${g.pk} Service ${s} is not enabled"
         ifvarclass => "!${s}_enabled";
 }
 
@@ -359,7 +359,7 @@ field_edits:
         comment => "Match a line starting like key = something";
 
 insert_lines:
-  "$(index) : $($(v)[$(index)])",
+  "$(index) : $($(v)[$(index)])"
          comment => "Insert a variable definition",
       ifvarclass => "!$(cindex[$(index)])_in_file";
 }
@@ -497,7 +497,7 @@ bundle agent verify_system_user(user,password,home) {
 
   commands:
     !has_user::
-      "$(sipx.adduser)",
+      "$(sipx.adduser)"
         comment => "Creating user $(user)",
         contain => in_shell,
         args => "-d $(home) -s /sbin/nologin -M $(user) && \


### PR DESCRIPTION
The policy file parser is stricter in CFEngine >=3.5.0. The parser is now fully compliant with the CFEngine language syntax reference. The main difference you will encounter is that promiser/promisee no longer allows a comma at the end of the line.